### PR TITLE
Fixed missed name change

### DIFF
--- a/src/tests/test_leds.cpp
+++ b/src/tests/test_leds.cpp
@@ -1,4 +1,4 @@
-#include "yboard.h"
+#include "ybadge.h"
 
 #include "Arduino.h"
 


### PR DESCRIPTION
This wasn't caught when yboard was renamed to ybadge.